### PR TITLE
Refactor/build cycle manager

### DIFF
--- a/docs/build-cycle-manager/buildcyclemanager-plantuml-activity.txt
+++ b/docs/build-cycle-manager/buildcyclemanager-plantuml-activity.txt
@@ -1,0 +1,26 @@
+@startuml
+
+title BuildCycleManager::startBuild
+
+
+start
+
+fork
+  :1.createBuildRequest;
+fork again
+  :2. getSearchPaths;
+end fork
+
+:3. addChanges;
+
+:4. build;
+
+fork
+  :5. updateIndex;
+fork again
+  :6. updateValidationMarkers;
+end fork
+
+stop
+
+@enduml

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/XtextConfiguration.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/XtextConfiguration.xtend
@@ -10,6 +10,9 @@ public class XtextConfiguration extends DropwizardApplicationConfiguration {
 
 	@NotEmpty @JsonProperty
 	String localRepoFileRoot = 'repo'
+	
+	@JsonProperty
+	String[] indexSearchPaths = #['/src/main/java', '/src/test/java', '/build/classes/java/main']
 
 	@NotEmpty @JsonProperty
 	String remoteRepoUrl

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMap.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMap.xtend
@@ -46,7 +46,7 @@ class ValidationMarkerMap {
 		return validationMarkers.values
 	}
 
-	def waitForAnyNewMarkersSince(long lastAccessed, long timeoutMillis) {
+	def Iterable<ValidationSummary> waitForAnyNewMarkersSince(long lastAccessed, long timeoutMillis) {
 		return if (newMarkersAvailableSince(lastAccessed)) {
 			allMarkers
 		} else {

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerUpdater.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerUpdater.xtend
@@ -82,11 +82,11 @@ class ValidationMarkerUpdater implements IIssueHandler, IPostValidationCallback 
 	}
 
 	private def previouslyCollectedSummary(String path) {
-		collectedValidationSummaries.computeIfAbsent(path, [ValidationSummary.noMarkers(path)])
+		return collectedValidationSummaries.computeIfAbsent(path, [ValidationSummary.noMarkers(path)])
 	}
 
 	private def incrementFor(ValidationSummary summary, Issue issue) {
-		summary => [
+		return summary => [
 			switch (issue.severity) {
 				case ERROR:
 					errors = errors + 1

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
@@ -36,9 +36,10 @@ class BuildCycleManager {
 
 	def BuildRequest addChanges(BuildRequest request) {
 		return request => [
-			dirtyFiles += changeDetector.modifiedResources
-			deletedFiles += changeDetector.deletedResources
-		]
+			val changes = changeDetector.detectChanges(indexResourceSet)
+			dirtyFiles += changes.modifiedResources
+			deletedFiles += changes.deletedResources				
+			]
 	}
 
 	def BuildRequest createBuildRequest() {
@@ -81,6 +82,10 @@ class ChunkedResourceDescriptionsProvider {
 }
 
 interface ChangeDetector {
+	def ChangedResources detectChanges(ResourceSet resourceSet)
+}
+
+interface ChangedResources {
 
 	def Iterable<URI> getModifiedResources()
 

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
@@ -1,0 +1,89 @@
+package org.testeditor.web.xtext.index
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.xtext.build.BuildRequest
+import org.eclipse.xtext.build.IncrementalBuilder
+import org.eclipse.xtext.build.IndexState
+import org.eclipse.xtext.resource.IResourceServiceProvider
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions
+import org.testeditor.web.dropwizard.xtext.validation.ValidationMarkerUpdater
+
+@Singleton
+class BuildCycleManager {
+
+	@Inject ChangeDetector changeDetector
+	@Inject ValidationMarkerUpdater validationUpdater
+	@Inject XtextResourceSet indexResourceSet
+	@Inject IncrementalBuilder builder
+	@Inject ChunkedResourceDescriptionsProvider indexProvider
+	@Inject extension IResourceServiceProvider.Registry resourceServiceProviderFactory
+
+	var URI baseURI
+	var IndexState lastIndexState = new IndexState
+
+	def init(URI baseURI) {
+		this.baseURI = baseURI
+	}
+
+	def startBuild() {
+		createBuildRequest.addChanges.build.updateIndex
+		updateValidationMarkers
+	}
+
+	def BuildRequest addChanges(BuildRequest request) {
+		return request => [
+			dirtyFiles += changeDetector.modifiedResources
+			deletedFiles += changeDetector.deletedResources
+		]
+	}
+
+	def BuildRequest createBuildRequest() {
+		return new BuildRequest => [
+			baseDir = baseURI
+			afterValidate = validationUpdater
+			resourceSet = indexResourceSet
+			state = lastIndexState
+		]
+	}
+
+	def IndexState build(BuildRequest request) {
+		return builder.build(request, [getResourceServiceProvider]).indexState
+	}
+
+	def updateValidationMarkers() {
+		validationUpdater.updateMarkerMap
+	}
+
+	def updateIndex(IndexState indexState) {
+		index.setContainer(baseURI.toString, indexState.resourceDescriptions)
+	}
+
+	private def getIndex() {
+		indexProvider.getIndex(indexResourceSet)
+	}
+
+}
+
+class ChunkedResourceDescriptionsProvider {
+
+	def ChunkedResourceDescriptions getIndex(ResourceSet resourceSet) {
+		var index = ChunkedResourceDescriptions.findInEmfObject(resourceSet)
+		if (index === null) {
+			index = new ChunkedResourceDescriptions(emptyMap, resourceSet)
+		}
+		return index
+	}
+
+}
+
+interface ChangeDetector {
+
+	def Iterable<URI> getModifiedResources()
+
+	def Iterable<URI> getDeletedResources()
+
+}

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
@@ -31,11 +31,11 @@ class BuildCycleManager {
 	var IndexState lastIndexState = new IndexState
 	var String[] staticSearchPaths = null
 
-	def init(URI baseURI) {
+	def void init(URI baseURI) {
 		this.baseURI = baseURI
 	}
 
-	def startBuild() {
+	def void startBuild() {
 		createBuildRequest.addChanges.build.updateIndex
 		updateValidationMarkers
 	}
@@ -49,7 +49,7 @@ class BuildCycleManager {
 	}
 
 	def String[] getSearchPaths(BuildRequest request) {
-		getStaticSearchPaths + config.localRepoFileRoot.additionalSearchPaths()
+		return getStaticSearchPaths + config.localRepoFileRoot.additionalSearchPaths
 	}
 
 	def BuildRequest createBuildRequest() {
@@ -65,11 +65,11 @@ class BuildCycleManager {
 		return builder.build(request, [getResourceServiceProvider]).indexState
 	}
 
-	def updateValidationMarkers() {
+	def void updateValidationMarkers() {
 		validationUpdater.updateMarkerMap
 	}
 
-	def updateIndex(IndexState indexState) {
+	def void updateIndex(IndexState indexState) {
 		index.setContainer(baseURI.toString, indexState.resourceDescriptions)
 	}
 
@@ -82,7 +82,7 @@ class BuildCycleManager {
 	}
 
 	private def getIndex() {
-		indexProvider.getIndex(indexResourceSet)
+		return indexProvider.getIndex(indexResourceSet)
 	}
 
 }
@@ -100,24 +100,32 @@ class ChunkedResourceDescriptionsProvider {
 }
 
 interface IndexSearchPathProvider {
+
 	def String[] additionalSearchPaths(String rootPath)
+
 }
 
 interface ChangeDetector {
+
 	def ChangedResources detectChanges(ResourceSet resourceSet, String[] paths)
+
 }
 
 interface ChangedResources {
+
 	def Iterable<URI> getModifiedResources()
 
 	def Iterable<URI> getDeletedResources()
+
 }
 
 class SetBasedChangedResources implements ChangedResources {
+
 	val modifiedResources = <URI>newHashSet
 	val deletedResources = <URI>newHashSet
 
-	override Set<URI> getModifiedResources() { modifiedResources }
+	override Set<URI> getModifiedResources() { return modifiedResources }
 
-	override Set<URI> getDeletedResources() { deletedResources }
+	override Set<URI> getDeletedResources() { return deletedResources }
+
 }

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
@@ -29,7 +29,6 @@ class BuildCycleManager {
 
 	var URI baseURI
 	var IndexState lastIndexState = new IndexState
-	var firstBuild = true
 	var String[] staticSearchPaths = null
 
 	def init(URI baseURI) {
@@ -37,29 +36,20 @@ class BuildCycleManager {
 	}
 
 	def startBuild() {
-		startBuild(firstBuild)
-		firstBuild = false
-	}
-
-	private def startBuild(boolean firstBuild) {
-		createBuildRequest.addChanges(firstBuild).build.updateIndex
+		createBuildRequest.addChanges.build.updateIndex
 		updateValidationMarkers
 	}
 
-	def BuildRequest addChanges(BuildRequest request, boolean firstBuild) {
+	def BuildRequest addChanges(BuildRequest request) {
 		return request => [
-			if (firstBuild) {
-//				dirtyFiles += changeDetector.allResources(indexResourceSet)
-			} else {
-				val changes = changeDetector.detectChanges(indexResourceSet, searchPaths)
-				dirtyFiles += changes.modifiedResources
-				deletedFiles += changes.deletedResources
-			}
+			val changes = changeDetector.detectChanges(indexResourceSet, searchPaths)
+			dirtyFiles += changes.modifiedResources
+			deletedFiles += changes.deletedResources
 		]
 	}
 
-	def String[] getSearchPaths() {
-		getStaticSearchPaths + config.localRepoFileRoot.additionalSearchPaths
+	def String[] getSearchPaths(BuildRequest request) {
+		getStaticSearchPaths + config.localRepoFileRoot.additionalSearchPaths()
 	}
 
 	def BuildRequest createBuildRequest() {

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/FilterablePathTraverser.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/FilterablePathTraverser.xtend
@@ -1,0 +1,42 @@
+package org.testeditor.web.xtext.index.buildutils
+
+import com.google.common.base.Predicate
+import com.google.common.collect.Sets
+import java.io.File
+import java.io.FileFilter
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.mwe.PathTraverser
+
+/**
+ * Traverses only directories and files that are accepted by the provided filter.
+ * 
+ * Note that, if a directory is not accepted by the filter, its content will not
+ * be considered, either.
+ * Paths to archives passed to the traverser are handled as usual.
+ */
+@FinalFieldsConstructor
+class FilterablePathTraverser extends PathTraverser {
+
+	val FileFilter filter
+
+	override traverseDir(File file, Predicate<URI> isValidPredicate) {
+		val result = Sets.newHashSet
+		val files = file.listFiles(filter)
+		if (files === null) {
+			return result
+		}
+		for (File f : files) {
+			if (f.isDirectory()) {
+				result.addAll(traverseDir(f, isValidPredicate))
+			} else {
+				val uri = URI.createFileURI(f.getAbsolutePath())
+				if (isValidPredicate.apply(uri)) {
+					result.add(uri)
+				}
+			}
+		}
+		return result
+	}
+
+}

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/XtextBuilderUtils.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/XtextBuilderUtils.xtend
@@ -1,9 +1,10 @@
 package org.testeditor.web.xtext.index.buildutils
 
 import java.io.File
+import java.io.FileFilter
 import java.io.IOException
 import java.net.URLClassLoader
-import java.util.List
+import java.util.Set
 import java.util.jar.JarFile
 import java.util.jar.Manifest
 import java.util.zip.ZipException
@@ -20,17 +21,27 @@ class XtextBuilderUtils {
 
 	static val logger = LoggerFactory.getLogger(XtextBuilderUtils)
 
+	static def Set<URI> collectResources(Iterable<String> roots, ResourceSet resourceSet, Iterable<String> extensions) {
+		return collectResources(roots, resourceSet, extensions, null)
+	}
+
 	/**
 	 * copied and adapted from org.eclipse.xtext.builder.standalone.StandaloneBuilder
 	 */
-	static def List<URI> collectResources(Iterable<String> roots, ResourceSet resourceSet, Iterable<String> extensions) {
+	static def Set<URI> collectResources(Iterable<String> roots, ResourceSet resourceSet, Iterable<String> extensions, FileFilter filter) {
 		val nameBasedFilter = new NameBasedFilter
 
 		// TODO test with whitespaced file extensions
 		nameBasedFilter.setRegularExpression(".*\\.(?:(" + extensions.join("|") + "))$")
 		val resources = <URI>newArrayList
 
-		val modelsFound = new PathTraverser().resolvePathes(
+		val pathTraverser = if (filter === null) {
+				new PathTraverser
+			} else {
+				new FilterablePathTraverser(filter)
+			}
+
+		val modelsFound = pathTraverser.resolvePathes(
 			roots.toList,
 			[ input |
 				println('''URI: «input.toString»''')
@@ -47,7 +58,7 @@ class XtextBuilderUtils {
 				registerBundle(file)
 			}
 		]
-		return resources
+		return resources.toSet
 	}
 
 	/**

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/XtextBuilderUtils.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/buildutils/XtextBuilderUtils.xtend
@@ -64,7 +64,7 @@ class XtextBuilderUtils {
 	/**
 	 * copied and adapted from org.eclipse.xtext.builder.standalone.StandaloneBuilder
 	 */
-	static def registerBundle(File file) {
+	static def void registerBundle(File file) {
 
 		// copied from org.eclipse.emf.mwe.utils.StandaloneSetup.registerBundle(File)
 		var JarFile jarFile = null

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/persistence/GradleProjectIndexUpdater.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/persistence/GradleProjectIndexUpdater.xtend
@@ -41,7 +41,7 @@ class GradleProjectIndexUpdater extends IndexUpdater {
 				resourceSet = index.resourceSet
 				dirtyFiles = collectResources(
 					#[basePath + "/src/main/java", basePath + '/src/test/java', basePath + '/build/classes/java/main'] + jars, resourceSet,
-					languageAccessors.keySet)
+					languageAccessors.keySet).toList
 				afterValidate = validationMarkerUpdater
 			]
 

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
@@ -42,7 +42,8 @@ class BuildCycleManagerTest {
 	@Mock extension IResourceServiceProvider.Registry mockResourceServiceProviderRegistry
 	@Mock ChunkedResourceDescriptionsProvider indexProvider
 	@Mock ChunkedResourceDescriptions index
-	@InjectMocks extension BuildCycleManager unitUnderTest
+
+	@InjectMocks BuildCycleManager buildCycleManagerUnderTest
 
 	val expectedModifiedResources = #[URI.createFileURI('/path/to/modified/resource')]
 	val expectedDeletedResource = #[URI.createFileURI('/path/to/deleted/resource')]
@@ -98,7 +99,7 @@ class BuildCycleManagerTest {
 		val initialBuildRequest = new BuildRequest
 
 		// when
-		val actualBuildRequest = initialBuildRequest.addChanges
+		val actualBuildRequest = buildCycleManagerUnderTest.addChanges(initialBuildRequest)
 
 		// then
 		assertThat(actualBuildRequest.deletedFiles).containsOnly(expectedDeletedResource)
@@ -109,10 +110,10 @@ class BuildCycleManagerTest {
 	@Test
 	def void createBuildRequestSetsRequiredFields() {
 		// given
-		unitUnderTest.init(URI.createFileURI(config.localRepoFileRoot))
+		buildCycleManagerUnderTest.init(URI.createFileURI(config.localRepoFileRoot))
 
 		// when
-		val actualBuildRequest = unitUnderTest.createBuildRequest
+		val actualBuildRequest = buildCycleManagerUnderTest.createBuildRequest
 
 		// then
 		assertThat(actualBuildRequest.baseDir).isEqualTo(URI.createFileURI(config.localRepoFileRoot))
@@ -124,10 +125,10 @@ class BuildCycleManagerTest {
 	@Test
 	def void createBuildRequestAlwaysUsesSameResourceSet() {
 		// given
-		val firstBuildRequest = unitUnderTest.createBuildRequest
+		val firstBuildRequest = buildCycleManagerUnderTest.createBuildRequest
 
 		// when
-		val secondBuildRequest = unitUnderTest.createBuildRequest
+		val secondBuildRequest = buildCycleManagerUnderTest.createBuildRequest
 
 		// then
 		assertThat(firstBuildRequest.resourceSet).isSameAs(secondBuildRequest.resourceSet)
@@ -138,7 +139,7 @@ class BuildCycleManagerTest {
 		// given
 		val buildRequest = sampleBuildRequest
 		// when
-		val actualIndexState = unitUnderTest.build(buildRequest)
+		val actualIndexState = buildCycleManagerUnderTest.build(buildRequest)
 
 		// then
 		assertThat(actualIndexState.resourceDescriptions.exportedObjects.head.qualifiedName.toString).isEqualTo('Test')
@@ -149,7 +150,7 @@ class BuildCycleManagerTest {
 		// given
 		val buildRequest = sampleBuildRequest
 		// when
-		unitUnderTest.build(buildRequest)
+		buildCycleManagerUnderTest.build(buildRequest)
 
 		// then
 		verify(mockValidationMarkerUpdater).afterValidate(any, any)
@@ -161,7 +162,7 @@ class BuildCycleManagerTest {
 		val buildRequest = sampleBuildRequest
 		val resourceServiceRegistryCaptor = ArgumentCaptor.forClass(Function1)
 		// when
-		unitUnderTest.build(buildRequest)
+		buildCycleManagerUnderTest.build(buildRequest)
 
 		// then
 		verify(mockIncrementalBuilder).build(eq(sampleBuildRequest), resourceServiceRegistryCaptor.capture)
@@ -173,7 +174,7 @@ class BuildCycleManagerTest {
 	@Test
 	def void updateValidationMarkersInvokesUpdateMarkerMap() {
 		// when
-		unitUnderTest.updateValidationMarkers
+		buildCycleManagerUnderTest.updateValidationMarkers
 
 		// then
 		verify(mockValidationMarkerUpdater).updateMarkerMap
@@ -185,10 +186,10 @@ class BuildCycleManagerTest {
 		val exportedObjectNames = #['modelElement', 'anotherElement']
 		val newIndexState = getMockedIndexState(exportedObjectNames)
 		val baseURI = URI.createFileURI(config.localRepoFileRoot)
-		unitUnderTest.init(baseURI)
+		buildCycleManagerUnderTest.init(baseURI)
 
 		// when
-		unitUnderTest.updateIndex(newIndexState)
+		buildCycleManagerUnderTest.updateIndex(newIndexState)
 
 		// then
 		verify(index).setContainer(baseURI.toString, newIndexState.resourceDescriptions)

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
@@ -98,7 +98,7 @@ class BuildCycleManagerTest {
 		val initialBuildRequest = new BuildRequest
 
 		// when
-		val actualBuildRequest = initialBuildRequest.addChanges(false)
+		val actualBuildRequest = initialBuildRequest.addChanges
 
 		// then
 		assertThat(actualBuildRequest.deletedFiles).containsOnly(expectedDeletedResource)

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when
 class BuildCycleManagerTest {
 
 	@Mock ChangeDetector mockChangeDetector
+	@Mock ChangedResources mockChangedResources
 	@Mock XtextResourceSet mockResourceSet
 	@Mock ValidationMarkerUpdater mockValidationMarkerUpdater
 	@Mock IncrementalBuilder mockIncrementalBuilder
@@ -55,8 +56,9 @@ class BuildCycleManagerTest {
 			state = initialIndexState
 		]
 
-		when(mockChangeDetector.modifiedResources).thenReturn(expectedModifiedResources)
-		when(mockChangeDetector.deletedResources).thenReturn(expectedDeletedResource)
+		when(mockChangeDetector.detectChanges(mockResourceSet)).thenReturn(mockChangedResources)
+		when(mockChangedResources.modifiedResources).thenReturn(expectedModifiedResources)
+		when(mockChangedResources.deletedResources).thenReturn(expectedDeletedResource)
 
 		val builderResult = mock(IncrementalBuilder.Result)
 		val indexState = getMockedIndexState(#['Test'])

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerTest.xtend
@@ -1,0 +1,186 @@
+package org.testeditor.web.xtext.index
+
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.build.BuildRequest
+import org.eclipse.xtext.build.IncrementalBuilder
+import org.eclipse.xtext.build.IndexState
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.resource.IResourceServiceProvider
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions
+import org.eclipse.xtext.resource.impl.ResourceDescriptionsData
+import org.eclipse.xtext.resource.persistence.SerializableEObjectDescription
+import org.eclipse.xtext.xbase.lib.Functions.Function1
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.testeditor.web.dropwizard.xtext.validation.ValidationMarkerUpdater
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+
+class BuildCycleManagerTest {
+
+	@Mock ChangeDetector mockChangeDetector
+	@Mock XtextResourceSet mockResourceSet
+	@Mock ValidationMarkerUpdater mockValidationMarkerUpdater
+	@Mock IncrementalBuilder mockIncrementalBuilder
+	@Mock extension IResourceServiceProvider.Registry mockResourceServiceProviderRegistry
+	@Mock ChunkedResourceDescriptionsProvider indexProvider
+	@Mock ChunkedResourceDescriptions index
+	@InjectMocks extension BuildCycleManager unitUnderTest
+
+	val expectedModifiedResources = #[URI.createFileURI('/path/to/modified/resource')]
+	val expectedDeletedResource = #[URI.createFileURI('/path/to/deleted/resource')]
+	val initialIndexState = new IndexState
+
+	var BuildRequest sampleBuildRequest
+
+	@Before
+	def void setupChangeDetectorMock() {
+		MockitoAnnotations.initMocks(this)
+
+		sampleBuildRequest = new BuildRequest => [
+			baseDir = URI.createFileURI('/base/dir')
+			resourceSet = mockResourceSet
+			afterValidate = mockValidationMarkerUpdater
+			deletedFiles = expectedDeletedResource
+			dirtyFiles = expectedModifiedResources
+			state = initialIndexState
+		]
+
+		when(mockChangeDetector.modifiedResources).thenReturn(expectedModifiedResources)
+		when(mockChangeDetector.deletedResources).thenReturn(expectedDeletedResource)
+
+		val builderResult = mock(IncrementalBuilder.Result)
+		val indexState = getMockedIndexState(#['Test'])
+		when(builderResult.indexState).thenReturn(indexState)
+		when(mockIncrementalBuilder.build(eq(sampleBuildRequest), any)).thenAnswer [
+			<BuildRequest>getArgument(0).afterValidate.afterValidate(null, null)
+			builderResult
+		]
+
+		when(indexProvider.getIndex(mockResourceSet)).thenReturn(index)
+	}
+
+	private def getMockedIndexState(Iterable<String> eObjectNames) {
+		val indexState = mock(IndexState)
+		val resourceDescriptionsData = mock(ResourceDescriptionsData)
+		when(resourceDescriptionsData.exportedObjects).thenReturn(
+			eObjectNames.map [ eObjectName |
+			val desc = new SerializableEObjectDescription()
+			desc.qualifiedName = QualifiedName.create(eObjectName)
+			return desc
+		])
+		when(indexState.resourceDescriptions).thenReturn(resourceDescriptionsData)
+		return indexState
+	}
+
+	@Test
+	def void detectChangesReturnsModifiedFiles() {
+		// given
+		val initialBuildRequest = new BuildRequest
+
+		// when
+		val actualBuildRequest = initialBuildRequest.addChanges
+
+		// then
+		assertThat(actualBuildRequest.deletedFiles).containsOnly(expectedDeletedResource)
+		assertThat(actualBuildRequest.dirtyFiles).containsOnly(expectedModifiedResources)
+	}
+
+	@Test
+	def void createBuildRequestSetsRequiredFields() {
+		// given
+		unitUnderTest.init(URI.createFileURI('/base/dir'))
+
+		// when
+		val actualBuildRequest = unitUnderTest.createBuildRequest
+
+		// then
+		assertThat(actualBuildRequest.baseDir).isEqualTo(URI.createFileURI('/base/dir'))
+		assertThat(actualBuildRequest.resourceSet).isEqualTo(mockResourceSet)
+		assertThat(actualBuildRequest.afterValidate).isEqualTo(mockValidationMarkerUpdater)
+		assertThat(actualBuildRequest.state.getResourceDescriptions.exportedObjects).isEmpty
+	}
+
+	@Test
+	def void createBuildRequestAlwaysUsesSameResourceSet() {
+		// given
+		val firstBuildRequest = unitUnderTest.createBuildRequest
+
+		// when
+		val secondBuildRequest = unitUnderTest.createBuildRequest
+
+		// then
+		assertThat(firstBuildRequest.resourceSet).isSameAs(secondBuildRequest.resourceSet)
+	}
+
+	@Test
+	def void launchReturnsUpdatedIndexState() {
+		// given
+		val buildRequest = sampleBuildRequest
+		// when
+		val actualIndexState = unitUnderTest.build(buildRequest)
+
+		// then
+		assertThat(actualIndexState.resourceDescriptions.exportedObjects.head.qualifiedName.toString).isEqualTo('Test')
+	}
+
+	@Test
+	def void launchInvokesValidationMarkerUpdaterState() {
+		// given
+		val buildRequest = sampleBuildRequest
+		// when
+		unitUnderTest.build(buildRequest)
+
+		// then
+		verify(mockValidationMarkerUpdater).afterValidate(any, any)
+	}
+
+	@Test
+	def void launchInvokesBuilderWithResourceServiceRegistry() {
+		// given
+		val buildRequest = sampleBuildRequest
+		val resourceServiceRegistryCaptor = ArgumentCaptor.forClass(Function1)
+		// when
+		unitUnderTest.build(buildRequest)
+
+		// then
+		verify(mockIncrementalBuilder).build(eq(sampleBuildRequest), resourceServiceRegistryCaptor.capture)
+		val testURI = URI.createFileURI('test')
+		resourceServiceRegistryCaptor.value.apply(testURI)
+		verify(mockResourceServiceProviderRegistry).getResourceServiceProvider(testURI)
+	}
+
+	@Test
+	def void updateValidationMarkersInvokesUpdateMarkerMap() {
+		// when
+		unitUnderTest.updateValidationMarkers
+
+		// then
+		verify(mockValidationMarkerUpdater).updateMarkerMap
+	}
+
+	@Test
+	def void updateIndexPublishesNewIndexState() {
+		// given
+		val exportedObjectNames = #['modelElement', 'anotherElement']
+		val newIndexState = getMockedIndexState(exportedObjectNames)
+		val baseURI = URI.createFileURI('/base/dir')
+		unitUnderTest.init(baseURI)
+
+		// when
+		unitUnderTest.updateIndex(newIndexState)
+
+		// then
+		verify(index).setContainer(baseURI.toString, newIndexState.resourceDescriptions)
+	}
+
+}

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/IncrementalBuilderLearningTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/IncrementalBuilderLearningTest.xtend
@@ -4,8 +4,14 @@ import javax.inject.Inject
 import org.apache.commons.io.FileUtils
 import org.eclipse.xtext.build.BuildRequest
 import org.eclipse.xtext.build.IncrementalBuilder
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.resource.IResourceDescriptionsProvider
 import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions
+import org.eclipse.xtext.resource.impl.ResourceDescriptionsData
+import org.eclipse.xtext.resource.persistence.SerializableEObjectDescription
+import org.eclipse.xtext.resource.persistence.SerializableResourceDescription
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -19,6 +25,8 @@ class IncrementalBuilderLearningTest extends AbstractTestWithExampleLanguage {
 	@Inject IncrementalBuilder builder
 	@Inject extension IResourceServiceProvider.Registry languageRegistry
 	@Inject XtextResourceSet resourceSet
+	@Inject IResourceDescriptionsProvider indexProvider
+
 	@Rule public TemporaryFolder tmpFolder = new TemporaryFolder
 
 	@Test
@@ -86,8 +94,83 @@ class IncrementalBuilderLearningTest extends AbstractTestWithExampleLanguage {
 
 		// then
 		assertThat(actualResult).isNotNull
-		assertThat(actualResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString])
-			.containsOnly('World', 'AddedFile')
+		assertThat(actualResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString]).containsOnly('World', 'AddedFile')
+	}
+
+	@Test
+	def void updatesIndexStateForAlteredResource() {
+		// given
+		val testFile = tmpFolder.newFile('test.mydsl')
+		FileUtils.write(testFile, 'Hello World!', 'UTF-8')
+		val resource = resourceSet.getResource(testFile.absolutePath.createFileURI, true)
+		val initialRequest = new BuildRequest() => [
+			it.resourceSet = resourceSet
+			it.dirtyFiles = #[resource.URI]
+		]
+		val initialResult = builder.build(initialRequest, [getResourceServiceProvider])
+		assertThat(initialResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString]).containsOnly('World')
+
+		FileUtils.write(testFile, 'Hello AddedFile!', 'UTF-8')
+		val newRequest = new BuildRequest() => [
+			it.resourceSet = resourceSet
+			it.state = initialResult.indexState
+			it.dirtyFiles = #[resource.URI]
+		]
+
+		// when
+		val actualResult = builder.build(newRequest, [getResourceServiceProvider])
+
+		// then
+		assertThat(actualResult).isNotNull
+		assertThat(actualResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString]).containsOnly('AddedFile')
+	}
+
+	@Test
+	def void removesDeletedResource() {
+		// given
+		val testFile = tmpFolder.newFile('test.mydsl')
+		FileUtils.write(testFile, 'Hello World!', 'UTF-8')
+		val firstResource = resourceSet.getResource(testFile.absolutePath.createFileURI, true)
+		val newFile = tmpFolder.newFile('test2.mydsl')
+		FileUtils.write(newFile, 'Hello AddedFile!', 'UTF-8')
+		val secondResource = resourceSet.getResource(newFile.absolutePath.createFileURI, true)
+		val initialRequest = new BuildRequest() => [
+			it.resourceSet = resourceSet
+			dirtyFiles = #[firstResource.URI, secondResource.URI]
+		]
+		val initialResult = builder.build(initialRequest, [getResourceServiceProvider])
+		assertThat(initialResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString]).containsOnly('World', 'AddedFile')
+
+		val deletedResourceRequest = new BuildRequest() => [
+			it.resourceSet = resourceSet
+			state = initialResult.indexState
+			deletedFiles = #[secondResource.URI]
+		]
+
+		// when
+		val actualResult = builder.build(deletedResourceRequest, [getResourceServiceProvider])
+
+		// then
+		assertThat(actualResult).isNotNull
+		assertThat(actualResult.indexState.resourceDescriptions.exportedObjects.map[qualifiedName.toString]).containsOnly('World')
+	}
+
+	@Test
+	def void newChunkedResourceDescriptionsGetRegistered() {
+		// given
+		val initialData = #{'test' -> new ResourceDescriptionsData(
+			#[new SerializableResourceDescription => [
+				descriptions = #[new SerializableEObjectDescription => [
+					qualifiedName = QualifiedName.create('SampleExportedObject')
+				]]
+			]]
+		)}
+
+		// when
+		val index = new ChunkedResourceDescriptions(initialData, resourceSet)
+
+		// then
+		assertThat(indexProvider.getResourceDescriptions(resourceSet)).isSameAs(index)
 	}
 
 }

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
@@ -65,7 +65,7 @@ class XtextIndexTest extends AbstractTestWithExampleLanguage {
 		val initRequest = new BuildRequest => [
 			baseDir = tmpFolder.root.absolutePath.createFileURI
 			resourceSet = indexResourceSet
-			dirtyFiles = collectResources(#[jarFilename], indexResourceSet, languages.keySet)
+			dirtyFiles = collectResources(#[jarFilename], indexResourceSet, languages.keySet).toList
 		]
 
 		// when

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
@@ -35,7 +35,7 @@ import static extension org.testeditor.web.xtext.index.buildutils.XtextBuilderUt
 
 class XtextIndexTest extends AbstractTestWithExampleLanguage {
 
-	@Rule public val tmpFolder = new TemporaryFolder
+	@Rule public val TemporaryFolder tmpFolder = new TemporaryFolder
 
 	@Inject IncrementalBuilder builder
 	@Inject LanguageAccessFactory languageAccessFactory
@@ -102,7 +102,7 @@ class XtextIndexTest extends AbstractTestWithExampleLanguage {
 		return new ILanguageConfiguration() {
 
 			override getOutputConfigurations() {
-				configurationProvider.getOutputConfigurations()
+				return configurationProvider.getOutputConfigurations()
 			}
 
 			override getSetup() {

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/buildutils/FilterablePathTraverserTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/buildutils/FilterablePathTraverserTest.xtend
@@ -1,0 +1,74 @@
+package org.testeditor.web.xtext.index.buildutils
+
+import java.io.FileFilter
+import java.io.FileOutputStream
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.eclipse.emf.common.util.URI.*
+
+class FilterablePathTraverserTest {
+
+	@Rule public TemporaryFolder tmpDir = new TemporaryFolder
+
+	@Test
+	def void skipsFilesAndFoldersAccordingToFilterRule() {
+		// given
+		tmpDir.newFile('do.not.skipME')
+		tmpDir.newFile('you-should-skip-me')
+		tmpDir.newFolder('include')
+		tmpDir.newFile('include/me')
+		tmpDir.newFolder('you', 'must', 'skip-me')
+		tmpDir.newFile('you/must/skip-me/and-not-even-consider-me')
+
+		val FileFilter filter = [!absolutePath.contains('skip-me')]
+		val unitUnderTest = new FilterablePathTraverser(filter)
+
+		// when
+		val actual = unitUnderTest.resolvePathes(#[tmpDir.root.absolutePath], [true])
+
+		// then
+		tmpDir.root => [
+			assertThat(actual.values).containsOnly(
+				createFileURI(absolutePath + '/do.not.skipME'),
+				createFileURI(absolutePath + '/include/me')
+			)
+		]
+	}
+
+	@Test
+	def void filteringDoesNotAffectArchives() {
+		// given
+		val folderPath = tmpDir.newFolder('folder').absolutePath
+		val archivePath = tmpDir.root.absolutePath + '/archive.jar'
+		
+		tmpDir.newFile('folder/do.not.skipME')
+		tmpDir.newFile('folder/you-should-skip-me')
+		
+		new JarOutputStream(new FileOutputStream(archivePath)) => [
+			putNextEntry(new JarEntry('you-must-not-skip-me'))
+			putNextEntry(new JarEntry('youMustInclude.me'))
+			close
+		]
+
+		val FileFilter filter = [!absolutePath.contains('skip-me')]
+		val unitUnderTest = new FilterablePathTraverser(filter)
+
+		// when
+		val actual = unitUnderTest.resolvePathes(#[folderPath, archivePath], [true])
+		
+		// then
+		tmpDir.root => [
+			assertThat(actual.values).containsOnly(
+				createFileURI(folderPath + '/do.not.skipME'),
+				createURI('archive:' + createFileURI(archivePath) + '!/you-must-not-skip-me'),
+				createURI('archive:' + createFileURI(archivePath) + '!/youMustInclude.me')
+			)
+		]
+	}
+
+}


### PR DESCRIPTION
This introduces the class `BuildCycleManager`, which is meant as a central hub to manage and streamline the incremental build process (it is not actually being used, yet). A build is invoked through `startBuild`, which does not take any parameters – the build cycle manager takes care of all necessary steps, internally. These steps are currently: 

![simple activity diagram of the `BuildCycleManager`'s build steps](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/test-editor/xtext-dropwizard/186916bba5df6bae9aa9f6bbbf3b4308d5db8497/docs/build-cycle-manager/buildcyclemanager-plantuml-activity.txt)

The class itself contains basically no real business logic, but instead relies on its dependencies to which it delegates performing these steps. It is meant to be extensible, either by extending and overriding methods representing individual build steps, or (better) by wiring in custom implementations of the 'worker' dependencies, for which interfaces to conform to are defined.

Due to the lack of business logic, the corresponding `BuildCycleManagerTest` was more a tool during TDD / pairing, so it mostly seems to test the mocks it sets up… However, the tests also document assumptions wrt pre-/postconditions and usage of the class. It may also be reused for integration testing by replacing the mocks with actual implementations, once those are completed.