### PR TITLE
fix issue of not being able to find project description

### DIFF
--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/xtext/index/BuildCycleManager.xtend
@@ -96,27 +96,32 @@ class ChunkedResourceDescriptionsProvider implements IResourceDescriptionsProvid
 	public static val String PROJECT_NAME = 'projectName'
 
 	@Accessors(PUBLIC_GETTER)
-	@Inject
 	XtextResourceSet indexResourceSet
 
 	@Inject(optional=true)
 	@Named(PROJECT_NAME)
 	String projectName
 
+	@Inject
+	new(XtextResourceSet indexResourceSet) {
+		this.indexResourceSet = indexResourceSet
+	}
+
 	var Supplier<ProjectDescription> project = memoize[
 		new ProjectDescription => [
 			name = projectName ?: 'Unnamed Project'
-			attachToEmfObject(indexResourceSet)
 		]
 	]
 
 	def ProjectDescription getProject() {
+		indexResourceSet.registerWithProject
 		return project.get
 	}
 
 	def ChunkedResourceDescriptions getResourceDescriptions() {
 		var index = ChunkedResourceDescriptions.findInEmfObject(indexResourceSet)
 		if (index === null) {
+			indexResourceSet.registerWithProject
 			index = new ChunkedResourceDescriptions(emptyMap, indexResourceSet)
 		}
 		return index


### PR DESCRIPTION
Should fix an issue with test editor backend not being able to locate the project description associated with a given resource set.

* constructor injection is introduced, as otherwise different injectors will re-inject new resource sets, even if the instance itself is already present and scoped as singleton.
* whenever the project description or the resource descriptions are retrieved, the provider ensures that the former is registered with the resource set