### PR TITLE
fix ValidationMarkerUpdater to explicitly report absence of issues

### DIFF
--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/XtextApplication.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/XtextApplication.xtend
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response.ResponseBuilder
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.xtext.ISetup
 import org.eclipse.xtext.XtextRuntimeModule
-import org.eclipse.xtext.builder.standalone.IIssueHandler
 import org.eclipse.xtext.builder.standalone.compiler.EclipseJavaCompiler
 import org.eclipse.xtext.builder.standalone.compiler.IJavaCompiler
 import org.eclipse.xtext.common.TerminalsStandaloneSetup
@@ -25,7 +24,6 @@ import org.eclipse.xtext.resource.containers.ProjectDescriptionBasedContainerMan
 import org.eclipse.xtext.web.server.model.IWebResourceSetProvider
 import org.testeditor.web.dropwizard.DropwizardApplication
 import org.testeditor.web.dropwizard.xtext.validation.ValidationMarkerResource
-import org.testeditor.web.dropwizard.xtext.validation.ValidationMarkerUpdater
 import org.testeditor.web.xtext.index.BuildCycleManager
 import org.testeditor.web.xtext.index.ChangeDetector
 import org.testeditor.web.xtext.index.ChunkedResourceDescriptionsProvider
@@ -57,7 +55,6 @@ abstract class XtextApplication<T extends XtextConfiguration> extends Dropwizard
 		modules += [ binder |
 			binder.bind(IndexFilter).annotatedWith(Names.named(ChangeFilter.FILTER_CHANGES_FOR_INDEX)).to(LanguageExtensionBasedIndexFilter)
 			binder.bind(ChangeDetector).to(TestEditorChangeDetector)
-			binder.bind(IIssueHandler).to(ValidationMarkerUpdater)
 			binder.bind(ResponseBuilder).toProvider[Response.ok]
 			binder.bind(new TypeLiteral<Iterable<ISetup>>() {}).toProvider[getLanguageSetups(indexModule)]
 			binder.bind(IndexSearchPathProvider).toInstance[#[]]

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMap.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMap.xtend
@@ -24,7 +24,13 @@ class ValidationMarkerMap {
 	def void updateMarkers(Iterable<ValidationSummary> summaries) {
 		if (!summaries.empty) {
 			val currentUpdate = futureUpdate
-			summaries.forEach[summary|validationMarkers.put(summary.path, summary)]
+			summaries.forEach [ summary |
+				if (summary.hasNoIssues) {
+					validationMarkers.remove(summary.path)
+				} else {
+					validationMarkers.put(summary.path, summary)
+				}
+			]
 			futureUpdate = new CompletableFuture<Iterable<ValidationSummary>>()
 			currentUpdate.complete(allMarkers)
 			val now = System.currentTimeMillis
@@ -56,6 +62,10 @@ class ValidationMarkerMap {
 
 	private def newMarkersAvailableSince(long lastAccessed) {
 		return lastAccessed <= lastUpdated.get
+	}
+
+	private def hasNoIssues(ValidationSummary summary) {
+		return summary.errors === 0 && summary.warnings === 0 && summary.infos === 0
 	}
 
 }

--- a/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerUpdater.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/main/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerUpdater.xtend
@@ -45,9 +45,8 @@ import static com.google.common.base.Suppliers.memoize
  * itself. 
  */
 @Singleton
-class ValidationMarkerUpdater implements IIssueHandler, IPostValidationCallback {
+class ValidationMarkerUpdater implements IPostValidationCallback {
 
-	@Inject DefaultIssueHandler delegateForDefaultBehavior
 	@Inject extension ValidationMarkerMap validationMarkerMap
 	@Inject Provider<XtextConfiguration> config
 
@@ -62,20 +61,9 @@ class ValidationMarkerUpdater implements IIssueHandler, IPostValidationCallback 
 	}
 
 	override afterValidate(URI resourceURI, Iterable<Issue> issues) {
-		issues.forEach[previouslyCollectedSummary(resourceURI.toResourcePath).incrementFor(it)]
+		val validationSummaryForResource = previouslyCollectedSummary(resourceURI.toResourcePath)
+		issues.forEach[validationSummaryForResource.incrementFor(it)]
 		return true
-	}
-
-	override boolean handleIssue(Iterable<Issue> issues) {
-		issues?.forEach [
-			val path = uriToProblem.toResourcePath
-			if (path !== null) {
-				previouslyCollectedSummary(path).incrementFor(it)
-			} else {
-				logger.warn('''Could not determine resource path for issue: «it»''')
-			}
-		]
-		return delegateForDefaultBehavior.handleIssue(issues)
 	}
 
 	def void updateMarkerMap() {

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMapTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/dropwizard/xtext/validation/ValidationMarkerMapTest.xtend
@@ -40,6 +40,27 @@ class ValidationMarkerMapTest {
 	}
 
 	@Test
+	def void removesValidationMarkersAfterUpdateWithNullSummary() {
+		// given
+		val unitUnderTest = new ValidationMarkerMap
+		val initialSummaries = #[
+			new ValidationSummary('path', 1, 2, 3),
+			new ValidationSummary('another/path', 42, 23, 3)
+		]
+		val summariesAfterFix = #[
+			new ValidationSummary('path', 0, 0, 0)
+		]
+		unitUnderTest.updateMarkers(initialSummaries)
+		assertThat(unitUnderTest.allMarkers).containsExactlyInAnyOrder(initialSummaries)
+		
+		// when
+		unitUnderTest.updateMarkers(summariesAfterFix)
+
+		// then
+		assertThat(unitUnderTest.allMarkers).containsExactlyInAnyOrder(#[new ValidationSummary('another/path', 42, 23, 3)])
+	}
+
+	@Test
 	def void returnsNoMarkersDefaultWhenPathIsNotFound() {
 		// given
 		val unitUnderTest = new ValidationMarkerMap

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerIntegrationTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/BuildCycleManagerIntegrationTest.xtend
@@ -48,6 +48,7 @@ import org.xtext.example.mydsl.ide.MyDslIdeModule
 import static com.google.common.base.Suppliers.memoize
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.*
+import org.testeditor.web.dropwizard.xtext.validation.ValidationSummary
 
 class BuildCycleManagerIntegrationTest extends AbstractTestWithExampleLanguage {
 
@@ -204,7 +205,6 @@ class BuildCycleManagerIntegrationTest extends AbstractTestWithExampleLanguage {
 	@Test
 	def void startBuildUpdatesValidationMarkers() {
 		// given
-		val expectedValidationSummaries = #[]
 		val actualValidationSummaries = ArgumentCaptor.forClass(Iterable)
 		
 		// when
@@ -212,7 +212,7 @@ class BuildCycleManagerIntegrationTest extends AbstractTestWithExampleLanguage {
 
 		// then
 		verify(validationMarkers).updateMarkers(actualValidationSummaries.capture)
-		assertThat(actualValidationSummaries.value).isEqualTo(expectedValidationSummaries)
+		assertThat(actualValidationSummaries.value).containsOnly(ValidationSummary.noMarkers('src/test/java/Demo.mydsl'))
 	}
 	
 	@Test

--- a/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
+++ b/org.testeditor.web.dropwizard.xtext/src/test/java/org/testeditor/web/xtext/index/XtextIndexTest.xtend
@@ -13,19 +13,13 @@ import org.eclipse.xtext.ISetup
 import org.eclipse.xtext.XtextRuntimeModule
 import org.eclipse.xtext.build.BuildRequest
 import org.eclipse.xtext.build.IncrementalBuilder
-import org.eclipse.xtext.builder.standalone.IIssueHandler
 import org.eclipse.xtext.builder.standalone.ILanguageConfiguration
 import org.eclipse.xtext.builder.standalone.LanguageAccessFactory
-import org.eclipse.xtext.builder.standalone.compiler.EclipseJavaCompiler
-import org.eclipse.xtext.builder.standalone.compiler.IJavaCompiler
-import org.eclipse.xtext.generator.AbstractFileSystemAccess
 import org.eclipse.xtext.generator.OutputConfigurationProvider
 import org.eclipse.xtext.resource.XtextResourceSet
-import org.eclipse.xtext.xbase.testing.RegisteringFileSystemAccess
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.testeditor.web.dropwizard.xtext.validation.ValidationMarkerUpdater
 import org.testeditor.web.xtext.index.buildutils.XtextBuilderUtils
 import org.xtext.example.mydsl.MyDslStandaloneSetup
 
@@ -91,12 +85,6 @@ class XtextIndexTest extends AbstractTestWithExampleLanguage {
 	override def void collectModules(List<Module> modules) {
 		super.collectModules(modules)
 		modules.add(new XtextRuntimeModule)
-		modules += [ binder |
-			binder.bind(AbstractFileSystemAccess).to(RegisteringFileSystemAccess).asEagerSingleton
-			binder.bind(IJavaCompiler).to(EclipseJavaCompiler)
-			binder.bind(IIssueHandler).to(ValidationMarkerUpdater)
-		]
-
 	}
 
 	private def ILanguageConfiguration createLanguageConfiguration(Class<? extends ISetup> setupClass) {


### PR DESCRIPTION
Should fix issues with "stale" validation markers, i.e. given a particular resource, if there were issues reported for it at some point, and then that resource is modified so that all issues are fixed, the old validation markers were still shown. This only happened on an update that removed *all* remaining issues.

The actual fix is basically only [one line](https://github.com/test-editor/xtext-dropwizard/compare/bug/stale-validation-markers?expand=1#diff-56dbed7fa331de0d37f68634bd377d69R64), which causes an empty validation summary to be created, even if the list of issues passed into the method is empty.